### PR TITLE
add pkg.svelte

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "dist/heatmap.cjs.js",
   "module": "dist/heatmap.esm.js",
   "browser": "dist/heatmap.js",
+  "svelte": "src/heatmap.html",
   "scripts": {
     "build": "cross-env NODE_ENV=production rollup -c",
     "dev": "cross-env NODE_ENV=development rollup -c -w",


### PR DESCRIPTION
This field allows Svelte apps using this component to import the source directly, rather than importing the compiled bundle, meaning some code is deduplicated. (Currently only works if the app is built with rollup-plugin-svelte, but the intention is to use it elsewhere.)

For non-Svelte apps, nothing changes — they still import the built file.