### PR TITLE
use heatmap.html as entry point

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,10 +36,8 @@
     "mocha": "^4.0.1",
     "rollup": "^0.51.5",
     "rollup-plugin-babel": "^3.0.2",
-    "rollup-plugin-commonjs": "^8.2.6",
     "rollup-plugin-eslint": "^4.0.0",
     "rollup-plugin-istanbul": "^1.1.0",
-    "rollup-plugin-node-resolve": "^3.0.0",
     "rollup-plugin-svelte": "^3.1.0",
     "sinon": "^4.1.2"
   },

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,8 +1,6 @@
 import babel from 'rollup-plugin-babel';
-import commonjs from 'rollup-plugin-commonjs';
 import istanbul from 'rollup-plugin-istanbul';
 import pkg from './package.json';
-import resolve from 'rollup-plugin-node-resolve';
 import svelte from 'rollup-plugin-svelte';
 
 const plugins = [
@@ -31,22 +29,18 @@ if (process.env.NODE_ENV === 'test') {
 export default [
     // Browser friendly UMD build.
     {
-        input: 'src/main.js',
+        input: 'src/heatmap.html',
         output: {
             file: pkg.browser,
             format: 'umd',
         },
         name: 'SvelteHeatmap',
-        plugins: [
-            resolve(),
-            commonjs(),
-        ].concat(plugins),
+        plugins,
     },
 
     // CommonJS (for Node) and ES module (for bundlers) build
     {
-        input: 'src/main.js',
-        external: ['ms'],
+        input: 'src/heatmap.html',
         output: [
             { file: pkg.main, format: 'cjs' },
             { file: pkg.module, format: 'es' }

--- a/src/main.js
+++ b/src/main.js
@@ -1,3 +1,0 @@
-import Heatmap from './heatmap.html';
-
-export default Heatmap;


### PR DESCRIPTION
It's possible to use a non-JS file as the entry point in a Rollup config, which means the `main.js` file is unnecessary! Also in this PR I got rid of a couple of unused plugins from the project template.