### PR TITLE
Correct typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Horizontal space to allocate for day labels. If this is `0`, day labels will not
 
 ##### `dayLabels`
 
-Array of strings to use for day labels. Defaults to `['', 'Mon', '', 'Web', '', 'Fri', '']`.
+Array of strings to use for day labels. Defaults to `['', 'Mon', '', 'Wed', '', 'Fri', '']`.
 
 ##### `fontColor`
 


### PR DESCRIPTION
Just `'Wed'` instead of `'Web'` for the `dayLabels` prop.

On a related documentation note: using the component, I had to use the `document.querySelector('#target')` value for the `target` key. The documented value `#target` did not work for me.