### PR TITLE
Add monthLayout option

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,10 @@ Vertical space to allocate for month labels. If this is `0`, month labels will n
 
 Array of strings to use for month labels. Defaults to `['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec']`.
 
+##### `monthLayout`
+
+An array of possible layout options when `view` is set to `monthly`. The following options are possible (rows x columns): `1x12` (default), `2x6`, `3x4`, `4x3`, `6x2`, `12x1`.
+
 ##### `startDate`
 
 Date object representing the first day of the graph. If omitted, this will default to the first day of the `month` or `year`, based on the current `view`.

--- a/index.html
+++ b/index.html
@@ -117,9 +117,10 @@
                     data: fakeData,
                     emptyColor: '#ecedf0',
                     monthGap: 20,
-                    startDate: moment().subtract(5, 'months').toDate(),
+                    startDate: moment().subtract(11, 'months').toDate(),
                     endDate: moment().toDate(),
                     view: 'monthly',
+                    monthLayout: '3x4',
                 },
                 target: document.querySelector('#monthly'),
             });

--- a/package-lock.json
+++ b/package-lock.json
@@ -2817,16 +2817,6 @@
         "@types/istanbul-lib-coverage": "*"
       }
     },
-    "@types/istanbul-reports": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-1.1.2.tgz",
-      "integrity": "sha512-P/W9yOX/3oPZSpaYOCQzGqgCQRXn0FFO/V8bWrCQs+wLmvVVxk6CRBXALEvNs9OHIatlnlFokfhuDo2ug01ciw==",
-      "dev": true,
-      "requires": {
-        "@types/istanbul-lib-coverage": "*",
-        "@types/istanbul-lib-report": "*"
-      }
-    },
     "@types/node": {
       "version": "14.0.11",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-14.0.11.tgz",

--- a/src/views/Month.svelte
+++ b/src/views/Month.svelte
@@ -1,4 +1,4 @@
-<g transform={`translate(${translation}, 0)`}>
+<g transform={`translate(${translationX}, ${translationY})`}>
     {#each days as day}
         <Cell
             color={day.color}
@@ -25,11 +25,14 @@
 
 <script>
 import Cell from './Cell.svelte';
-import { getWeekIndex, stringifyDate } from '../utils/date';
+import { getWeekIndex } from '../utils/date';
 
-$: translation = (((7 * cellRect) - cellGap) + monthGap) * index;
+$: monthHeight = (6 * cellRect) + monthGap + monthLabelHeight
+$: monthWidth = (7 * cellRect) + monthGap
 
-export let cellGap;
+$: translationX = monthWidth * (index % monthCols);
+$: translationY = monthHeight * (Math.floor(index / monthCols));
+
 export let cellRadius;
 export let cellRect;
 export let cellSize;
@@ -41,4 +44,5 @@ export let index;
 export let monthGap;
 export let monthLabelHeight;
 export let monthLabels;
+export let monthCols;
 </script>


### PR DESCRIPTION
As suggested in #135 I hereby submit a pull request for your consideration and review. I tried to respect the code conventions and to be clear in my commit messages. The current layout (all months in a row) remains the default if the `monthLayout` option is not used.

I'd be happy to make further changes if necessary so that you can integrate this PR as easily as possible.

Thanks for your great work which is very useful to me. :-)