### PR TITLE
[FIX] Update month labels to function on firefox

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,10 @@
 {
   "author": "Scott Bedard",
+  "contributors": [
+    "Eric Weidow (https://github.com/studsministern)"
+  ],
   "bugs": {
-    "url": "https://github.com/scottbedard/svelte-heatmap/issues"
+    "url": "https://github.com/studsministern/svelte-heatmap/issues"
   },
   "description": "A light weight and customizable version of GitHub's contribution graph",
   "devDependencies": {
@@ -22,7 +25,7 @@
     "src",
     "dist"
   ],
-  "homepage": "https://github.com/scottbedard/svelte-heatmap",
+  "homepage": "https://github.com/studsministern/svelte-heatmap",
   "keywords": [
     "svelte"
   ],
@@ -32,7 +35,7 @@
   "name": "svelte-heatmap",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/scottbedard/svelte-heatmap.git"
+    "url": "git+https://github.com/studsministern/svelte-heatmap.git"
   },
   "svelte": "src/index.js",
   "scripts": {
@@ -42,5 +45,5 @@
     "watch": "rollup -c -w"
   },
   "unpkg": "dist/index.umd.min.js",
-  "version": "1.0.2"
+  "version": "1.0.3"
 }

--- a/src/SvelteHeatmap.svelte
+++ b/src/SvelteHeatmap.svelte
@@ -30,7 +30,7 @@
                 </text>
             {/each}
         {/if}
-        <g transform={`translate(${dayLabelWidth})`}>
+        <g transform={`translate(${dayLabelWidth}, ${fontSize})`}>
             {#each chunks as chunk, index}
                 <Week
                     cellRadius={cellRadius}
@@ -115,8 +115,8 @@ $: chunks = view === 'monthly'
 $: weekRect = (7 * cellRect) - cellGap;
 
 $: height = view === 'monthly'
-    ? (6 * cellRect) - cellGap + monthLabelHeight // <- max of 6 rows in monthly view
-    : weekRect + monthLabelHeight;
+    ? (6 * cellRect) - cellGap + monthLabelHeight + fontSize // <- max of 6 rows in monthly view
+    : weekRect + monthLabelHeight + fontSize;
 
 $: width = view === 'monthly'
     ? ((weekRect + monthGap) * chunks.length) - monthGap

--- a/src/SvelteHeatmap.svelte
+++ b/src/SvelteHeatmap.svelte
@@ -123,6 +123,6 @@ $: width = view === 'monthly'
     : (cellRect * chunks.length) - cellGap + dayLabelWidth;
 
 $: dayLabelPosition = index => {
-    return (cellRect * index) + (cellRect / 2) + monthLabelHeight;
+    return (cellRect * index) + (cellRect / 2) + monthLabelHeight + fontSize;
 }
 </script>

--- a/src/views/Month.svelte
+++ b/src/views/Month.svelte
@@ -1,4 +1,4 @@
-<g transform={`translate(${translation}, 0)`}>
+<g transform={`translate(${translation}, ${fontSize})`}>
     {#each days as day}
         <Cell
             color={day.color}


### PR DESCRIPTION
Hi,

I noticed that month labels weren't rendering correctly in Firefox, this is highlighted in issue #144. The problem can be seen by comparing the look of https://svelte-heatmap.netlify.app/ in Firefox and (for example) Google Chrome.

This is a small fix where the `g` elements are transformed so the labels are visible. The height for the heatmap is also increased so cells are not cropped due to the transform.